### PR TITLE
Fix errors with jquery and wp_enqueue being called outside of a handler.

### DIFF
--- a/gas-injector.php
+++ b/gas-injector.php
@@ -13,11 +13,6 @@
  */
 
 /**
- * Loads jQuery if not loaded.
- */
-wp_enqueue_script('jquery');
-
-/**
  * WP Hooks
  **/
 add_action('init', 'load_gas_injector_translation_file');
@@ -53,6 +48,11 @@ function admin_register_gas_for_wordpress_head() {
  * Inserts the Google Analytics tracking code and domain.
  */
 function insert_google_analytics_code_and_domain() {
+    /**
+     * Loads jQuery if not loaded.
+     */
+    wp_enqueue_script('jquery');
+
     if (!current_user_can('edit_posts')  && get_option('ua_tracking_code') != "") {
         echo "<!-- GAS Injector for Wordpress from http://www.geckosolutions.se/blog/wordpress-plugins/ -->\n";
         echo get_gas_tracking_code();


### PR DESCRIPTION
Ran into issues with WP 4.0 and this plugin where there were errors beign thrown about wp_enqueue. 

```
Notice: wp_enqueue_script was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks. 
```

Originally thought that the fix would be to enqueue all of the scripts somehow but remedied the issues with the wp_enqueue errors by simply moving the jquery enequeue into the wp_head handler.
